### PR TITLE
Replace bitnami kubectl

### DIFF
--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -207,6 +207,10 @@ kyverno:
       requests:
         cpu: 96m
         memory: 192Mi
+  policyReportsCleanup:
+    image:
+      registry: registry.k8s.io
+      repository: kubectl
   # Disabled since Argo CD currently do not support pre-delete Helm hooks
   # See https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
   webhooksCleanup:

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -219,4 +219,4 @@ kyverno:
     image:
       registry: registry.opensuse.org
       repository: opensuse/kubectl
-      tag: 1.30
+      tag: "1.30"

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -215,3 +215,6 @@ kyverno:
   # See https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
   webhooksCleanup:
     enabled: false
+    image:
+      registry: registry.k8s.io
+      repository: kubectl

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -211,6 +211,7 @@ kyverno:
     image:
       registry: registry.k8s.io
       repository: kubectl
+      tag: v1.30.2
   # Disabled since Argo CD currently do not support pre-delete Helm hooks
   # See https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
   webhooksCleanup:
@@ -218,3 +219,5 @@ kyverno:
     image:
       registry: registry.k8s.io
       repository: kubectl
+      tag: v1.30.2
+

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -209,15 +209,14 @@ kyverno:
         memory: 192Mi
   policyReportsCleanup:
     image:
-      registry: registry.k8s.io
-      repository: kubectl
-      tag: v1.30.2
+      registry: registry.opensuse.org
+      repository: opensuse/kubectl
+      tag: 1.30
   # Disabled since Argo CD currently do not support pre-delete Helm hooks
   # See https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
   webhooksCleanup:
     enabled: false
     image:
-      registry: registry.k8s.io
-      repository: kubectl
-      tag: v1.30.2
-
+      registry: registry.opensuse.org
+      repository: opensuse/kubectl
+      tag: 1.30

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -211,7 +211,7 @@ kyverno:
     image:
       registry: registry.opensuse.org
       repository: opensuse/kubectl
-      tag: 1.30
+      tag: &kubectlTag "1.30"
   # Disabled since Argo CD currently do not support pre-delete Helm hooks
   # See https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
   webhooksCleanup:
@@ -219,4 +219,4 @@ kyverno:
     image:
       registry: registry.opensuse.org
       repository: opensuse/kubectl
-      tag: "1.30"
+      tag: *kubectlTag

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -209,14 +209,10 @@ kyverno:
         memory: 192Mi
   policyReportsCleanup:
     image:
-      registry: registry.opensuse.org
-      repository: opensuse/kubectl
-      tag: &kubectlTag "1.30"
+      repository: &bitnamiRepo bitnamilegacy/kubectl
   # Disabled since Argo CD currently do not support pre-delete Helm hooks
   # See https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks
   webhooksCleanup:
     enabled: false
     image:
-      registry: registry.opensuse.org
-      repository: opensuse/kubectl
-      tag: *kubectlTag
+      repository: *bitnamiRepo


### PR DESCRIPTION
This pull request makes configuration updates to the `values-subchart-overrides.yaml` file for Kyverno, focusing on image repository settings for cleanup jobs. The main changes ensure that both the policy reports cleanup and webhooks cleanup jobs use the same image repository reference, improving consistency and maintainability.

Configuration consistency improvements:

* Added an `image.repository` field for `policyReportsCleanup`, referencing the `bitnamilegacy/kubectl` image via the `bitnamiRepo` anchor.
* Updated the `webhooksCleanup` configuration to include an `image.repository` field, also referencing the shared `bitnamiRepo` anchor for consistency.